### PR TITLE
Allowing the peripherals to drop off if they haven't been discovered …

### DIFF
--- a/Rower/Concept2-SDK/Delegates/CentralManagerDelegate.swift
+++ b/Rower/Concept2-SDK/Delegates/CentralManagerDelegate.swift
@@ -78,8 +78,7 @@ final class CentralManagerDelegate:NSObject, CBCentralManagerDelegate {
     func centralManager(_ central: CBCentralManager, didFailToConnect peripheral: CBPeripheral, error: Error?) {
         logger.info("didFailToConnectPeripheral \(peripheral) \(error?.localizedDescription ?? "")")
         postPerformanceMonitorNotificationForPeripheral(peripheral: peripheral, lastError: error)
-    }
-    
+    }    
     
     func centralManager(_ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Error?) {
         logger.info("didDisconnectPeripheral \(peripheral) \(error?.localizedDescription ?? "")")

--- a/Rower/Concept2-SDK/PerformanceMonitor.swift
+++ b/Rower/Concept2-SDK/PerformanceMonitor.swift
@@ -43,11 +43,13 @@ public final class PerformanceMonitor
     public static let DidUpdateStateNotification = "PerformanceMonitorDidUpdateStateNotification"
     
     //
-    var peripheral:CBPeripheral
+    public var peripheral:CBPeripheral
     lazy var peripheralDelegate = PeripheralDelegate()
     
     /// Last error received during connect/disconnect or discovery
-    var lastError: Error?
+    public var lastError: Error?
+    
+    public var lastDiscovered = Date()
     
     // MARK: Basic Information
     public var peripheralName:String { get { return peripheral.name ?? "Unknown" } }

--- a/Rower/Concept2-SDK/Stores/PerformanceMonitorStore.swift
+++ b/Rower/Concept2-SDK/Stores/PerformanceMonitorStore.swift
@@ -13,37 +13,57 @@ let PerformanceMonitorStoreDidAddItemNotification = "PerformanceMonitorStoreDidA
 let PerformanceMonitorStoreDidRemoveItemNotification = "PerformanceMonitorStoreDidRemoveItemNotification"
 
 final class PerformanceMonitorStore {
-  // Singleton
-  static let sharedInstance = PerformanceMonitorStore()
-  
-  //////////////////////////////////////////////////////////////////////////////////////////////////
-  var performanceMonitors = Set<PerformanceMonitor>()
-
-  func addPerformanceMonitor(performanceMonitor:PerformanceMonitor) {
-    performanceMonitors.insert(performanceMonitor)
+    // Singleton
+    static let sharedInstance = PerformanceMonitorStore()
     
-    NotificationCenter.default.post(
-        name: NSNotification.Name(rawValue: PerformanceMonitorStoreDidAddItemNotification),
-      object: self)
-  }
-  
-  func performanceMonitorWithPeripheral(peripheral:CBPeripheral) -> PerformanceMonitor? {
-    var pm:PerformanceMonitor?
+    //////////////////////////////////////////////////////////////////////////////////////////////////
+    var performanceMonitors = Set<PerformanceMonitor>()
     
-    performanceMonitors.forEach { (performanceMonitor:PerformanceMonitor) -> () in
-      if performanceMonitor.peripheral == peripheral {
-        pm = performanceMonitor
-      }
+    func addPerformanceMonitor(performanceMonitor:PerformanceMonitor) {
+        performanceMonitors.insert(performanceMonitor)
+        
+        NotificationCenter.default.post(
+            name: NSNotification.Name(rawValue: PerformanceMonitorStoreDidAddItemNotification),
+            object: self)
     }
     
-    return pm
-  }
-  
-  func removePerformanceMonitor(performanceMonitor:PerformanceMonitor) {
-    performanceMonitors.remove(performanceMonitor)
+    func performanceMonitorWithPeripheral(peripheral:CBPeripheral) -> PerformanceMonitor? {
+        var pm:PerformanceMonitor?
+        
+        performanceMonitors.forEach { (performanceMonitor:PerformanceMonitor) -> () in
+            if performanceMonitor.peripheral == peripheral {
+                pm = performanceMonitor
+            }
+        }
+        
+        return pm
+    }
     
-    NotificationCenter.default.post(
-        name: NSNotification.Name(rawValue: PerformanceMonitorStoreDidRemoveItemNotification),
-      object: self)
-  }
+    func removePerformanceMonitor(performanceMonitor:PerformanceMonitor) {
+        performanceMonitors.remove(performanceMonitor)
+        
+        NotificationCenter.default.post(
+            name: NSNotification.Name(rawValue: PerformanceMonitorStoreDidRemoveItemNotification),
+            object: self)
+    }
+    
+    func removeOlderThan(time: TimeInterval) {
+        guard performanceMonitors.count > 0 else { return }
+        let updated = performanceMonitors.filter( { $0.lastDiscovered.timeIntervalSinceNow > -time })
+        if updated.count != performanceMonitors.count {
+            performanceMonitors = updated
+            NotificationCenter.default.post(
+                name: NSNotification.Name(rawValue: PerformanceMonitorStoreDidRemoveItemNotification),
+                object: self)
+        }
+    }
+    
+    func removeAll() {
+        performanceMonitors.removeAll()
+        
+        NotificationCenter.default.post(
+            name: NSNotification.Name(rawValue: PerformanceMonitorStoreDidRemoveItemNotification),
+            object: self)
+    }
+    
 }


### PR DESCRIPTION
…recently.

Previously, the peripherals could just stick around forever. This is one of the issues that was causing the connection to fail.